### PR TITLE
IT Bookstoreのサーバ落ちた時用のダミーデータを追加した

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -5,7 +5,33 @@ class BooksController < ApplicationController
   
   def search
     @search_form = SearchBooksForm.new(search_books_params)
+    
+    # IT BookstoreからのJSON戻り値を@recordsに格納する
     @records = @search_form.query()["books"]
+
+    # IT Bookstoreのサーバが落ちている時は↑の@records行をコメントアウトして↓のダミーデータを使う
+   
+=begin 
+    @records = [
+      {
+        "title"    => "Practical MongoDB",
+        "subtitle" => "Architecting, Developing, and Administering MongoDB",
+        "isbn13"   => "9781484206485",
+        "price"    => "$0.0",
+        "image"    => "https://itbook.store/img/books/9781484206485.png",
+        "url"      => "https://itbook.store/books/9781484206485"
+      },
+      {
+        "title"    => "The Definitive Guide to MongoDB, 3rd Edition",
+        "subtitle" => "A complete guide to dealing with Big Data using MongoDB",
+        "isbn13"   => "9781484211830",
+        "price"    => "$47.11",
+        "image"    => "https://itbook.store/img/books/9781484211830.png",
+        "url"      => "https://itbook.store/books/9781484211830"
+      }
+    ]
+=end
+
   end
   
   private


### PR DESCRIPTION
## チケットへのリンク

* https://example.com

## やったこと

* ダミーの本データを追加した。

## やらないこと

* サーバエラー時の処理(ユーザーにその旨通知するページを作る)は別途必要。授業内ではそこまでやらなくても良いかも。

## できるようになること（ユーザ目線）

* 無し

## できなくなること（ユーザ目線）

* 無し

## 動作確認
- [x] サーバーを起動できて、トップページを表示できるか？
- [x] 検索ボタンを押して、結果が表示されるか？

## その他

* 無し

