### PR TITLE
USDJPYの為替レートだけを返すように修正

### DIFF
--- a/app/controllers/get_exchange_rates_controller.rb
+++ b/app/controllers/get_exchange_rates_controller.rb
@@ -4,8 +4,9 @@ class GetExchangeRatesController < ApplicationController
   def getRate
     html = open('http://www.gaitameonline.com/rateaj/getrate').read
     json = JSON.parse(html)['quotes']
-    json.each do |data|
-      puts "通貨:#{data['currencyPairCode']} 最高値:#{data['high']} 最安値:#{data['low']} ASK:#{data['ask']} BID:#{data['bid']} 開始値:#{data['open']}"
-    end
+    usdjpy =json[20]['open']
+    puts "USDJPY:#{usdjpy}"
+    usdjpy
   end
 end
+


### PR DESCRIPTION
## チケットへのリンク

* https://github.com/machong/Easy_TechBook_Search/issues/20

## やったこと
為替レートのみを戻り値として受け取れるようになった。
* このプルリクで何をしたのか？

## やらないこと

* このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。）
為替レートを使った値段の計算は別のタスクで行う。
## できるようになること（ユーザ目線）

* 何ができるようになるのか？（あれば。無いなら「無し」でOK）
なし
## できなくなること（ユーザ目線）

* 何ができなくなるのか？（あれば。無いなら「無し」でOK）
なし！
## 動作確認
- [x] サーバーを起動できて、トップページを表示できるか？
- [x] 検索ボタンを押して、結果が表示されるか？

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
* 
### スクリーンショット
![image](https://user-images.githubusercontent.com/21151267/147949774-81a401df-197d-4c73-be80-ff310ac16740.png)
