### PR TITLE
価格でソートする機能追加（価格情報を文字列として扱っています）

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -5,7 +5,11 @@ class BooksController < ApplicationController
     @search_form = SearchBooksForm.new(search_books_params)
 
     # IT BookstoreからのJSON戻り値を@recordsに格納する
-    @records = @search_form.query['books']
+    unless params[:sort_by].nil? then
+      @records = @search_form.query().sort(sort_by: params[:sort_by], ascending: params[:ascending])["books"]
+    else      
+      @records = @search_form.query().sort()["books"]
+    end
 
     # IT Bookstoreのサーバが落ちている時は↑の@records行をコメントアウトして↓のダミーデータを使う
 

--- a/app/forms/search_books_form.rb
+++ b/app/forms/search_books_form.rb
@@ -8,18 +8,32 @@ class SearchBooksForm
 
   attribute :keyword, :string
 
-  def query
-    if !keyword.empty?
-      keyword_mod = keyword.gsub(' ', '+')
+  def query()
+    if !self.keyword.empty? then
+      keyword_mod = self.keyword.gsub(' ', '+')
       uri = URI.parse(format('https://api.itbook.store/1.0/search/%<x>s', x: keyword_mod))
       https = Net::HTTP.new(uri.host, uri.port)
       https.use_ssl = true
       req = Net::HTTP::Get.new(uri.path)
       res = https.request(req)
       @hash = JSON.parse(res.body)
-    elsif keyword.empty?
-      @hash = { books: [] }
+    elsif
+      @hash = {books:[]}
     end
-    @hash
+    return self
   end
+
+  def sort(sort_by='price', ascending = true)
+    unless @hash["books"].nil? then
+      if sort_by == "price" then
+        if ascending == true then
+          @hash["books"].sort_by!{|v| v["price"]}
+        else
+          @hash["books"].sort_by!{|v| -v["price"]}
+        end
+      end
+    end
+    return @hash
+  end
+  
 end

--- a/app/views/books/search.html.erb
+++ b/app/views/books/search.html.erb
@@ -117,8 +117,8 @@
 						表示順<span class="caret"></span>
 						</button>
 						<ul class="dropdown-menu" aria-labelledby="dropdownMenuButton1">
-							<li><a class="dropdown-item" href="#">安い順</a></li>
-							<li><a class="dropdown-item" href="#">高い順</a></li>
+							<li><a class="dropdown-item" href="?sort_by=price&ascending=false">安い順</a></li>
+							<li><a class="dropdown-item" href="?sort_by=price&ascending=true">高い順</a></li>
 							<li><a class="dropdown-item" href="#">ダウンロード回数多い順</a></li>
 							<li><a class="dropdown-item" href="#">ダウンロード回数少ない順</a></li>
 						</ul>


### PR DESCRIPTION
## チケットへのリンク

* https://github.com/machong/Easy_TechBook_Search/issues/32

## やったこと

* 価格でソートする機能追加（価格情報を文字列として扱う）

## やらないこと

* 価格情報を数値に変換してソート（後で対応）
* 出版日でソート
* 書籍名でソート

## できるようになること（ユーザ目線）

* 検索結果を価格でソート

## できなくなること（ユーザ目線）

* 無し

## 動作確認
- [ 〇] サーバーを起動できて、トップページを表示できるか？
- [ 〇] 検索ボタンを押して、結果が表示されるか？

## その他

* 検索後、何故かドロップダウンリストが動作しないので、デフォルトの昇順のみ確認済。

