### PR TITLE
検索結果に本の概要を表示

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -1,4 +1,7 @@
 require_relative '../forms/search_books_form'
+require 'net/http'
+require 'uri'
+require 'json'
 
 class BooksController < ApplicationController
   def search
@@ -8,7 +11,6 @@ class BooksController < ApplicationController
     @records = @search_form.query['books']
 
     # IT Bookstoreのサーバが落ちている時は↑の@records行をコメントアウトして↓のダミーデータを使う
-
     #
     #     @records = [
     #       {
@@ -28,7 +30,21 @@ class BooksController < ApplicationController
     #         "url"      => "https://itbook.store/books/9781484211830"
     #       }
     #     ]
+
+    # IT BookstoreからのJSON戻り値(詳細版)を@detailed_recordsに格納する
+    @detailed_records = []
+    @records.each do |book|
+      uri = URI.parse('https://api.itbook.store/1.0/books/' + book["isbn13"])
+      https = Net::HTTP.new(uri.host, uri.port)
+      https.use_ssl = true
+      req = Net::HTTP::Get.new(uri.path)
+      res = https.request(req)
+      @detailed_records.push(JSON.parse(res.body))
+    end
+
   end
+
+
 
   private
 

--- a/app/views/books/search.html.erb
+++ b/app/views/books/search.html.erb
@@ -129,7 +129,7 @@
 				<!-- BEGIN TABLE RESULT -->
 				<div class="table-responsive">
 				  <table class="table table-hover">
-                                    <% unless @records.nil? then  @records.each do |result| %>
+                                    <% unless @detailed_records.nil? then  @detailed_records.each do |result| %>
                                       <tbody> 
                                         <td class="image">
                                           <a href="<%= result["url"] %>">
@@ -143,6 +143,7 @@
                                                 <%= result["title"] %>
                                               </a>
                                             </h4>
+                                            <p class="serach-result-itemheading"><%= result["desc"] %></p>
                                           </div>
                                         </td>
                                         <td class="price text-right"> <%= result["price"] %> </td>
@@ -286,6 +287,5 @@
 <%= puts @records %>
 
 -->
-
 
 


### PR DESCRIPTION
## チケットへのリンク

* https://github.com/machong/Easy_TechBook_Search/issues/35

## やったこと

* @detailed_recordにAPI戻り値(詳細版)を格納
* 検索結果に本の概要を表示

## やらないこと

* 概要の翻訳(馬さんと連携)

## できるようになること（ユーザ目線）

* 本のタイトルと価格に加えて概要も表示

## できなくなること（ユーザ目線）

* 無し

## 動作確認
- [x] サーバーを起動できて、トップページを表示できるか？
- [x] 検索ボタンを押して、結果が表示されるか？

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）

