### PR TITLE
外為オンラインAPIによるドル円レート取得→書籍価格を円換算

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -53,14 +53,13 @@ class BooksController < ApplicationController
     end
 
     # 現時点でのドル円レートを取得
-    # rate = GetExchangeRatesController.new
-    # yen_rate = rate.getRate
+    rate = GetExchangeRatesController.new
+    yen_rate = rate.getRate.to_f
 
-    # @detailed_recordsのpriceの値を文字列から数字にした上で円換算
+    # @detailed_recordsのpriceの値を文字列から数字にした上で円換算(小数点以下切り上げ)
     @detailed_records&.each do |detailed_book|
       detailed_book['price'] = detailed_book['price'][1..].to_f
-      # detailed_book["price"] *= yen_rate
-      detailed_book['price'] *= 114 # 今はダミーでドル円レートを114にしている
+      detailed_book["price"] *= yen_rate
       detailed_book['price'] = detailed_book['price'].ceil
     end
 


### PR DESCRIPTION
## チケットへのリンク

* https://github.com/machong/Easy_TechBook_Search/issues/56

## やったこと

* 外為オンラインのAPIより取得したドル円レートで、検索結果の価格を円換算する

## やらないこと

* 無し

## できるようになること（ユーザ目線）

* 書籍の価格が、現時点での日本円価格で表示される

## できなくなること（ユーザ目線）

* 無し

## 動作確認
- [x] サーバーを起動できて、トップページを表示できるか？
- [x] 検索ボタンを押して、結果が表示されるか？

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）

